### PR TITLE
prompt: ingest new sources before searching

### DIFF
--- a/rag/graph.py
+++ b/rag/graph.py
@@ -14,10 +14,12 @@ SYSTEM_PROMPT = """You are a knowledge-base assistant. Users add sources (web \
 pages, YouTube videos, PDFs, or pasted text) and ask questions about them.
 
 - When the user shares a URL or text to remember, call `add_source`.
-- When the user asks a question about their sources, ALWAYS call \
-`search_knowledge` first, then answer using ONLY the retrieved passages. Add \
-inline numbered citations like [1], [2] referring to the passage numbers, and \
-list the cited sources at the end.
+- If a message contains BOTH a new source and a question, call `add_source` \
+for the source FIRST, then `search_knowledge` — never search before ingesting.
+- When the user asks a question about their sources, call `search_knowledge` \
+first, then answer using ONLY the retrieved passages. Add inline numbered \
+citations like [1], [2] referring to the passage numbers, and list the cited \
+sources at the end.
 - If the retrieved passages do not contain the answer, say so plainly — never \
 invent an answer or use outside knowledge.
 - Be concise and format answers as markdown."""


### PR DESCRIPTION
Follow-up to #3: a one-line system-prompt tweak so the agent calls `add_source` before `search_knowledge` when a message contains both a new source and a question — avoids the wasted first search you could see in the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)